### PR TITLE
[3776] Java - change the way the Azure function infrastructure is deployed

### DIFF
--- a/deploy/azure/app/servicebus/function.tf
+++ b/deploy/azure/app/servicebus/function.tf
@@ -32,29 +32,16 @@ resource "azurerm_storage_account" "sa_listener" {
 }
 
 # The app plans for the functions
-resource "azurerm_app_service_plan" "app_sp_publisher" {
-  name                = "service-plan-${var.function-publisher-name}"
+resource "azurerm_app_service_plan" "app_sp" {
+  name                = var.app-service-plan-name
   resource_group_name = var.resource_group_name
   location            = var.resource_group_location
   kind                = "linux"
   reserved            = true
 
   sku {
-    tier = "ElasticPremium"
-    size = "EP1"
-  }
-}
-
-resource "azurerm_app_service_plan" "app_sp_listener" {
-  name                = "service-plan-${var.function-listener-name}"
-  resource_group_name = var.resource_group_name
-  location            = var.resource_group_location
-  kind                = "linux"
-  reserved            = true
-
-  sku {
-    tier = "ElasticPremium"
-    size = "EP1"
+    tier = "Standard"
+    size = "S1"
   }
 }
 
@@ -67,7 +54,7 @@ resource "azurerm_function_app" "function_publisher" {
     azurerm_servicebus_namespace.sb
   ]
 
-  app_service_plan_id        = azurerm_app_service_plan.app_sp_publisher.id
+  app_service_plan_id        = azurerm_app_service_plan.app_sp.id
   storage_account_name       = azurerm_storage_account.sa_publisher.name
   storage_account_access_key = azurerm_storage_account.sa_publisher.primary_access_key
 
@@ -90,7 +77,7 @@ resource "azurerm_function_app" "function_listener" {
     azurerm_servicebus_namespace.sb
   ]
 
-  app_service_plan_id        = azurerm_app_service_plan.app_sp_listener.id
+  app_service_plan_id        = azurerm_app_service_plan.app_sp.id
   storage_account_name       = azurerm_storage_account.sa_listener.name
   storage_account_access_key = azurerm_storage_account.sa_listener.primary_access_key
 

--- a/deploy/azure/app/servicebus/vars.tf
+++ b/deploy/azure/app/servicebus/vars.tf
@@ -58,6 +58,11 @@ variable "cosmosdb_lease_collection_name" {
 
 # Optional variables
 # These have default values that can be overriden as required
+variable "app-service-plan-name" {
+  type = string
+  default = "app-sp-events"
+}
+
 variable "function-publisher-name" {
   type    = string
   default = "function-publisher"


### PR DESCRIPTION
📲 What

Change the tier for the Azure App Service Plan from Elastic Premium to Standard and only deploy one of these. Both functions will be deployed to the same App Service Plan.

🤔 Why

The EP tier was originally used as it was thought this was what was required for running Containers. However this is not the case.

Running two App Service Plans was a mistake.

The reason for doing this is to reduce costs.

🛠 How

In the Terraform template perform the following tasks:

    remove one of the app service plans
    change the SKU to Standard on the remaining App Service Plan and rename it
    Reconfigure both functions to use the single app service plan

👀 Evidence

All stages of the build have completed as normal

🕵️ How to test

Notes for QA
✅ Acceptance criteria Checklist

Code peer reviewed?
Documentation has been updated to reflect the changes?
Passing all automated tests, including a successful deployment?
Passing any exploratory testing?
Rebased/merged with latest changes from development and re-tested?
Meeting the Coding Standards?