### PR TITLE
Add GitHub release stage to build for stacks-java-cqrs-events

### DIFF
--- a/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
@@ -90,6 +90,8 @@ variables:
     value: 0
   - name: version_patch
     value: 0
+  - name: version_number
+    value: $(version_major).$(version_minor).$(version_patch)
 
   # PR / Branch vars
   - name: source_branch_ref
@@ -840,3 +842,40 @@ stages:
                         SB_SUBSCRIPTION: servicebus_subscription,
                         SB_CONNECTION_STRING: servicebus_connectionstring,
                       }
+
+  - stage: Release
+    dependsOn:
+      - Build
+      - Prod
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['create_release'], 'true'))
+    variables:
+      - group: amido-stacks-infra-credentials-nonprod
+    jobs:
+      - job: CreateGitHubRelease
+        pool:
+          vmImage: $(pool_vm_image)
+        steps:
+          # Check out the repo so that it can be tagged
+          - checkout: self
+            persistCredentials: true
+
+          # Create a tag in the code for this release
+          - task: Bash@3
+            displayName: Tag Code
+            inputs:
+              targetType: "inline"
+              script: |
+                git config user.name "BuildService"
+                git config user.email "builder@${COMPANY}.com"
+                git tag -a v${VERSION_NUMBER} -m "Release created by Azure DevOps"
+                git push origin v${VERSION_NUMBER}
+            env:
+              COMPANY: $(company)
+
+          # Create a GitHub release with these packages
+          - task: GitHubRelease@0
+            displayName: Create GitHub Release
+            inputs:
+              gitHubConnection: $(github_release_service_connection)
+              repositoryName: $(github_org)/$(self_repo)
+              tag: $(version_number)


### PR DESCRIPTION
:calling: What
Added release stage to the pipeline to create a GH release and tag the code with the build number.
:thinking_face: Why
The Stacks CLI uses version number tags to determine the version of the project to download. Latest maps to the lastest commit, but it supports downloading from specific tags. In this way we can support deploying older versions of the project.
:hammer_and_spanner: How
Added a new stage to the pipeline that tags the code and checks it into GitHub. Additionally a release, using the same tag, is created so that people have a reference to use.
Although no artifacts are released on GitHub this is done so that the GitHub Release API can be used (which the CLI supports).
:eyes: Evidence
Tests using a branch have been successful in creating the release.  
The release has been removed as we only want releases from master.

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
