### PR TITLE
Fix/mvn-settings-cli

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -50,7 +50,7 @@
         <netty.codec.http.version>4.1.72.Final</netty.codec.http.version>
         <netty.codec.http2.version>4.1.72.Final</netty.codec.http2.version>
         <netty.transport.native.epoll.version>4.1.72.Final</netty.transport.native.epoll.version>
-        <log4j-version>2.16.0</log4j-version>
+        <log4j-version>2.17.0</log4j-version>
         <logback.version>1.2.8</logback.version>
         <com.google.code.gson-version>2.8.9</com.google.code.gson-version>
 

--- a/stackscli.yml
+++ b/stackscli.yml
@@ -39,6 +39,7 @@ init:
       args: process-resources
               -f stacksclipom.xml
               -P copy-devops-resources
+              -P generate-settings-file
               -Dtarget.dir={{ .Project.Directory.WorkingDir }}
               --quiet
       desc: Coping build and deploy pipelines into the project structure
@@ -49,6 +50,7 @@ init:
       args: clean archetype:create-from-project
               -f ./java/pom.xml
               -DpropertyFile=./java/archetype.properties
+              -s {{ .Project.Directory.WorkingDir }}/settings.xml
               --quiet
       desc: Creating the archetype resources using the cqrs+events source code
 
@@ -119,6 +121,7 @@ init:
       args: clean archetype:create-from-project
               -f ./api-tests/pom-temp.xml
               -DpropertyFile=./api-tests/archetype.properties
+              -s {{ .Project.Directory.WorkingDir }}/settings.xml
               --quiet
       desc: Creating the archetype resources using the api-test source code
 
@@ -179,6 +182,7 @@ init:
       args: clean archetype:create-from-project
               -f ./api-tests-karate/pom.xml
               -DpropertyFile=./api-tests-karate/archetype.properties
+              -s {{ .Project.Directory.WorkingDir }}/settings.xml
               --quiet
       desc: Creating the archetype resources using the api-test-karate source code
 
@@ -213,5 +217,14 @@ init:
       cmd: mvn
       args: dependency:resolve
               -f {{ .Project.Directory.WorkingDir }}/api-tests-karate/pom.xml
+              --quiet
+      desc: Downloading maven dependencies for the api-tests-karate project
+
+    - action: cmd
+      cmd: mvn
+      args: clean
+              -f stacksclipom.xml
+              -P clean-workload
+              -Dtarget.dir={{ .Project.Directory.WorkingDir }}
               --quiet
       desc: Downloading maven dependencies for the api-tests-karate project

--- a/stackscli.yml
+++ b/stackscli.yml
@@ -42,7 +42,7 @@ init:
               -P generate-settings-file
               -Dtarget.dir={{ .Project.Directory.WorkingDir }}
               --quiet
-      desc: Coping build and deploy pipelines into the project structure
+      desc: Copying build and deploy pipelines into the project structure
 
     # Build archetype for the main code
     - action: cmd

--- a/stackscli.yml
+++ b/stackscli.yml
@@ -227,4 +227,4 @@ init:
               -P clean-workload
               -Dtarget.dir={{ .Project.Directory.WorkingDir }}
               --quiet
-      desc: Downloading maven dependencies for the api-tests-karate project
+      desc: Cleaning the project folder

--- a/stacksclipom.xml
+++ b/stacksclipom.xml
@@ -88,6 +88,39 @@
     </profile>
 
     <profile>
+      <id>generate-settings-file</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>ru.yaal.maven</groupId>
+            <artifactId>write-text-files-maven-plugin</artifactId>
+            <version>1.1</version>
+            <configuration>
+              <charset>UTF-8</charset>
+              <files>
+                <file>
+                  <path>${output.basedir}/settings.xml</path>
+                  <lines>
+                    <line><![CDATA[<settings></settings>]]></line>
+                  </lines>
+                </file>
+              </files>
+            </configuration>
+            <executions>
+              <execution>
+                <id>generate-settings-file</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>write-text-files</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
       <id>rename-source-folder</id>
       <build>
         <plugins>
@@ -108,6 +141,29 @@
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>clean-workload</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-clean-plugin</artifactId>
+            <version>3.1.0</version>
+            <configuration>
+              <filesets>
+                <fileset>
+                  <directory>${output.basedir}</directory>
+                  <includes>
+                    <include>**/settings.xml</include>
+                  </includes>
+                  <followSymlinks>false</followSymlinks>
+                </fileset>
+              </filesets>
+            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
4074-Settings.xml file not present

📲 What

Autogenerates the maven settings.xml file
🤔 Why

The archetype:generate-from-project needs the settings.xml to be present in the local environment. As this is not a mandatory maven file, we need to ensure that a version exists, if not the build will fail.
🛠 How

Plugin (write-text-files-maven-plugin) capable to generate files has been added to the stacksclipom.xml file


<groupId>ru.yaal.maven</groupId>
<artifactId>write-text-files-maven-plugin</artifactId>
<version>1.1</version>

Also two new profiles were added (generate-settings-file and clean-workload)

    generate-settings-file. Is responsible for generate and store a temp settings file in ${output.basedir}/settings.xml
    clean-workload. Deletes the file once the entire CLI process is completed.
#### 👀 Evidence

Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
