### PR TITLE
hotfix(): /java and /api-tests dependencies

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -64,11 +64,11 @@
     <owasp-dependency-check-plugin.version>6.5.0</owasp-dependency-check-plugin.version>
     <auth0-spring-security-api.version>1.4.1</auth0-spring-security-api.version>
     <io-projectreactor-netty.version>1.0.8</io-projectreactor-netty.version>
-    <netty.codec.http.version>4.1.72.Final</netty.codec.http.version>
-    <netty.codec.http2.version>4.1.72.Final</netty.codec.http2.version>
-    <netty.transport.native.epoll.version>4.1.72.Final</netty.transport.native.epoll.version>
+    <netty.codec.http.version>4.1.108.Final</netty.codec.http.version>
+    <netty.codec.http2.version>4.1.108.Final</netty.codec.http2.version>
+    <netty.transport.native.epoll.version>4.1.108.Final</netty.transport.native.epoll.version>
     <log4j-version>2.17.0</log4j-version>
-    <logback.version>1.2.8</logback.version>
+    <logback.version>1.2.13</logback.version>
     <com.google.code.gson-version>2.8.9</com.google.code.gson-version>
     <org.mapstruct.version>1.5.2.Final</org.mapstruct.version>
 


### PR DESCRIPTION
#### 📲 What

This PR updates critical dependencies in the Java module to address security vulnerabilities identified by Dependabot, ensuring compliance with ISO27001.

- Bumped Netty HTTP, HTTP2, and native epoll transport versions from 4.1.72 to 4.1.108  
- Upgraded Logback from 1.2.8 to 1.2.13

#### 🤔 Why

As part of our responsibilities under ISO27001, we are required to manage and mitigate risks associated with software vulnerabilities. By enforcing a secure version of webpack-dev-server, we reduce the risk of known vulnerabilities being exploited in our development environment. This proactive approach to dependency management demonstrates our commitment to maintaining the confidentiality, integrity, and availability of our information assets, as required by ISO27001 controls on software development and vulnerability management.

#### 🛠 How

Manual update of `pom.xml` in both `/api-tests` and `/java`

#### 👀 Evidence

Build currently broken due to OWASP Dependency Check / NVD API incompatibility.

```
================================================================================
- Statistics
================================================================================
>> Line Coverage: 826/1735 (48%)
>> Generated 1226 mutations Killed 288 (23%)
>> Mutations with no coverage 826. Test strength 72%
>> Ran 814 tests (0.66 tests per mutation)
```

#### 🕵️ How to test

```sh
cd java
./mvnw clean install -Plocal

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
