### PR TITLE
fix(): bump spring-web to 6.2.8

### DIFF
--- a/api-tests/pom.xml
+++ b/api-tests/pom.xml
@@ -44,7 +44,7 @@
         <httpclient.version>4.5.13</httpclient.version>
         <xerces.version>2.12.2</xerces.version>
         <commons.codec.version>1.15</commons.codec.version>
-        <spring.web.version>6.0.23</spring.web.version>
+        <spring.web.version>6.2.8</spring.web.version>
         <com.google.code.gson-version>2.8.9</com.google.code.gson-version>
 
         <!-- Maven plugins -->


### PR DESCRIPTION

#### 📲 What

bump spring-web to 6.2.8

#### 🤔 Why

As part of our responsibilities under ISO27001, we are required to manage and mitigate risks associated with software vulnerabilities. By enforcing a secure version of webpack-dev-server, we reduce the risk of known vulnerabilities being exploited in our development environment. This proactive approach to dependency management demonstrates our commitment to maintaining the confidentiality, integrity, and availability of our information assets, as required by ISO27001 controls on software development and vulnerability management.
#### 🛠 How

More in-depth discussion of the change or implementation.

#### 👀 Evidence

```
>> Line Coverage: 826/1735 (48%)
>> Generated 1226 mutations Killed 288 (23%)
>> Mutations with no coverage 826. Test strength 72%
>> Ran 812 tests (0.66 tests per mutation)
```

#### 🕵️ How to test

Build broken due to OWASP Dependency Check

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
