### PR TITLE
fix(): Update Netty deps (CVE-2025-55163)

### DIFF
--- a/api-tests/pom.xml
+++ b/api-tests/pom.xml
@@ -36,8 +36,8 @@
         <byte.buddy.version>1.12.4</byte.buddy.version>
         <springfox.swagger2.version>3.0.0</springfox.swagger2.version>
         <springfox.swagger-ui.version>3.0.0</springfox.swagger-ui.version>
-        <netty.codec.http.version>4.1.108.Final</netty.codec.http.version>
-        <netty.codec.http2.version>4.1.100.Final</netty.codec.http2.version>
+        <netty.codec.http.version>4.2.4.Final</netty.codec.http.version>
+        <netty.codec.http2.version>4.2.4.Final</netty.codec.http2.version>
         <netty.transport.native.epoll.version>4.1.72.Final</netty.transport.native.epoll.version>
         <json.version>20231013</json.version>
         <guava.version>32.0.0-jre</guava.version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -31,7 +31,6 @@
     <sqs.profile.name>no-sqs</sqs.profile.name>
 
     <!-- Stacks versions -->
-
     <stacks.core.commons.version>2.0.5</stacks.core.commons.version>
     <stacks.core.api.version>1.0.4.4-RELEASE</stacks.core.api.version>
     <stacks.azure.cosmos.version>2.1.1</stacks.azure.cosmos.version>
@@ -41,8 +40,7 @@
     <stacks.aws.version>1.0.2</stacks.aws.version>
     <stacks.azure.version>1.0.3</stacks.azure.version>
 
-
-
+    <!-- Java versions -->
     <java.version>11</java.version>
     <org.projectlombok.version>1.18.0</org.projectlombok.version>
     <org.springdoc-openapi.version>1.5.9</org.springdoc-openapi.version>
@@ -64,8 +62,8 @@
     <owasp-dependency-check-plugin.version>12.1.3</owasp-dependency-check-plugin.version>
     <auth0-spring-security-api.version>1.4.1</auth0-spring-security-api.version>
     <io-projectreactor-netty.version>1.0.8</io-projectreactor-netty.version>
-    <netty.codec.http.version>4.1.108.Final</netty.codec.http.version>
-    <netty.codec.http2.version>4.1.108.Final</netty.codec.http2.version>
+    <netty.codec.http.version>4.2.4.Final</netty.codec.http.version>
+    <netty.codec.http2.version>4.2.4.Final</netty.codec.http2.version>
     <netty.transport.native.epoll.version>4.1.108.Final</netty.transport.native.epoll.version>
     <log4j-version>2.17.0</log4j-version>
     <logback.version>1.2.13</logback.version>


### PR DESCRIPTION
#### 📲 What

Updates Java's Netty dependencies to the latest minor patch to mitigate CVE-2025-55163.

#### 🤔 Why

As part of our responsibilities under ISO27001, we are required to manage and mitigate risks associated with software vulnerabilities. By enforcing a secure version of Ensono Stacks, we reduce the risk of known vulnerabilities being exploited in our development environment. This proactive approach to dependency management demonstrates our commitment to maintaining the confidentiality, integrity, and availability of our information assets, as required by ISO27001 controls on software development and vulnerability management

#### 🛠 How

Updates Java's Netty dependencies from version 4.1.108.Final to 4.2.4.Final to address CVE-2025-55163, fulfilling ISO27001 security compliance requirements for vulnerability management.

- Updates Netty HTTP codec versions to mitigate security vulnerability
- Maintains consistency across main java/pom.xml and api-tests/pom.xml files
- Addresses security compliance requirements while preserving existing functionality

#### 👀 Evidence

```
================================================================================
- Timings
================================================================================
> pre-scan for mutations : < 1 second
> scan classpath : < 1 second
> coverage and dependency analysis : 13 seconds
> build mutation tests : < 1 second
> run mutation analysis : 6 minutes and 59 seconds
--------------------------------------------------------------------------------
> Total  : 7 minutes and 13 seconds
--------------------------------------------------------------------------------
================================================================================
- Statistics
================================================================================
>> Line Coverage: 826/1735 (48%)
>> Generated 1226 mutations Killed 288 (23%)
>> Mutations with no coverage 826. Test strength 72%
>> Ran 810 tests (0.66 tests per mutation)
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  07:45 min
[INFO] Finished at: 2025-08-15T10:22:03+01:00
[INFO] ------------------------------------------------------------------------
```

#### 🕵️ How to test

Following [ecosystem specific instructions for Java](https://ensono.github.io/stacks-secops-bok/ecosystems/java/).

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [X] Passing all automated tests, including a successful deployment?
- [X] Rebased/merged with latest changes from development and re-tested?
- [X] Meeting the Coding Standards?
