### PR TITLE
fix(): bump netty version to latest minor

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -62,8 +62,8 @@
     <owasp-dependency-check-plugin.version>12.1.3</owasp-dependency-check-plugin.version>
     <auth0-spring-security-api.version>1.4.1</auth0-spring-security-api.version>
     <io-projectreactor-netty.version>1.0.8</io-projectreactor-netty.version>
-    <netty.codec.http.version>4.2.4.Final</netty.codec.http.version>
-    <netty.codec.http2.version>4.2.4.Final</netty.codec.http2.version>
+    <netty.codec.http.version>4.2.6.Final</netty.codec.http.version>
+    <netty.codec.http2.version>4.2.6.Final</netty.codec.http2.version>
     <netty.transport.native.epoll.version>4.1.108.Final</netty.transport.native.epoll.version>
     <log4j-version>2.17.0</log4j-version>
     <logback.version>1.2.13</logback.version>


### PR DESCRIPTION
#### 📲 What

Bumps the version of Netty to the latest minor version (4.2.6) to mitigate CVE-2025-58056.

#### 🤔 Why

As part of our responsibilities under ISO27001, we are required to manage and mitigate risks associated with software vulnerabilities. By enforcing a secure version of Ensono Stacks, we reduce the risk of known vulnerabilities being exploited in our development environment. This proactive approach to dependency management demonstrates our commitment to maintaining the confidentiality, integrity, and availability of our information assets, as required by ISO27001 controls on software development and vulnerability management.

#### 🛠 How

Modified `pom.xml` to adopt the most recent 4.2 version, note 5.0.0 is currently in a prerelease state.

#### 👀 Evidence

TBC

#### 🕵️ How to test

Validated through passing CI.

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Passing all automated tests, including a successful deployment?
- [X] Rebased/merged with latest changes from development and re-tested?
- [X] Meeting the Coding Standards?
