### PR TITLE
fix(): netty version bump

### DIFF
--- a/api-tests/pom.xml
+++ b/api-tests/pom.xml
@@ -36,8 +36,8 @@
         <byte.buddy.version>1.12.4</byte.buddy.version>
         <springfox.swagger2.version>3.0.0</springfox.swagger2.version>
         <springfox.swagger-ui.version>3.0.0</springfox.swagger-ui.version>
-        <netty.codec.http.version>4.2.4.Final</netty.codec.http.version>
-        <netty.codec.http2.version>4.2.4.Final</netty.codec.http2.version>
+        <netty.codec.http.version>4.2.6.Final</netty.codec.http.version>
+        <netty.codec.http2.version>4.2.6.Final</netty.codec.http2.version>
         <netty.transport.native.epoll.version>4.1.72.Final</netty.transport.native.epoll.version>
         <json.version>20231013</json.version>
         <guava.version>32.0.0-jre</guava.version>


### PR DESCRIPTION
#### 📲 What

Bump netty in tests to latest patch.

#### 🤔 Why

As part of our responsibilities under ISO27001, we are required to manage and mitigate risks associated with software vulnerabilities. By enforcing a secure version of Ensono Stacks, we reduce the risk of known vulnerabilities being exploited in our development environment. This proactive approach to dependency management demonstrates our commitment to maintaining the confidentiality, integrity, and availability of our information assets, as required by ISO27001 controls on software development and vulnerability management.

#### 🛠 How

Modified `pom.xml`

#### 👀 Evidence

TBC

#### 🕵️ How to test

No CI associated with this repo.

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
