### PR TITLE
chore: bump netty to 4.2.9.Final

### DIFF
--- a/api-tests/pom.xml
+++ b/api-tests/pom.xml
@@ -36,9 +36,9 @@
         <byte.buddy.version>1.12.4</byte.buddy.version>
         <springfox.swagger2.version>3.0.0</springfox.swagger2.version>
         <springfox.swagger-ui.version>3.0.0</springfox.swagger-ui.version>
-        <netty.codec.http.version>4.2.6.Final</netty.codec.http.version>
-        <netty.codec.http2.version>4.2.6.Final</netty.codec.http2.version>
-        <netty.transport.native.epoll.version>4.1.72.Final</netty.transport.native.epoll.version>
+        <netty.codec.http.version>4.2.9.Final</netty.codec.http.version>
+        <netty.codec.http2.version>4.2.9.Final</netty.codec.http2.version>
+        <netty.transport.native.epoll.version>4.2.9.Final</netty.transport.native.epoll.version>
         <json.version>20231013</json.version>
         <guava.version>32.0.0-jre</guava.version>
         <httpclient.version>4.5.13</httpclient.version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -62,9 +62,9 @@
     <owasp-dependency-check-plugin.version>12.1.3</owasp-dependency-check-plugin.version>
     <auth0-spring-security-api.version>1.4.1</auth0-spring-security-api.version>
     <io-projectreactor-netty.version>1.0.8</io-projectreactor-netty.version>
-    <netty.codec.http.version>4.2.6.Final</netty.codec.http.version>
-    <netty.codec.http2.version>4.2.6.Final</netty.codec.http2.version>
-    <netty.transport.native.epoll.version>4.1.108.Final</netty.transport.native.epoll.version>
+    <netty.codec.http.version>4.2.9.Final</netty.codec.http.version>
+    <netty.codec.http2.version>4.2.9.Final</netty.codec.http2.version>
+    <netty.transport.native.epoll.version>4.2.9.Final</netty.transport.native.epoll.version>
     <log4j-version>2.17.0</log4j-version>
     <logback.version>1.2.13</logback.version>
     <com.google.code.gson-version>2.8.9</com.google.code.gson-version>


### PR DESCRIPTION
#### 📲 What
- Bump netty codec/http/http2/native-epoll to 4.2.9.Final in service and api-tests modules.

#### 🤔 Why
- Align to the latest patch to pick up upstream fixes and keep netty components consistent.

#### 🛠 How
- Updated netty version properties in java/pom.xml and api-tests/pom.xml.

#### 👀 Evidence
- Build & tests: ./mvnw clean verify (pass).

#### 🕵️ How to test
- Run: ./mvnw clean verify

#### ✅ Acceptance criteria Checklist
- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [x] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [x] Meeting the Coding Standards?