### PR TITLE
fix: bump Netty to fix CVE-2026-42577

### DIFF
--- a/api-tests/pom.xml
+++ b/api-tests/pom.xml
@@ -36,9 +36,9 @@
         <byte.buddy.version>1.18.8</byte.buddy.version>
         <springfox.swagger2.version>3.0.0</springfox.swagger2.version>
         <springfox.swagger-ui.version>3.0.0</springfox.swagger-ui.version>
-        <netty.codec.http.version>4.2.12.Final</netty.codec.http.version>
-        <netty.codec.http2.version>4.2.12.Final</netty.codec.http2.version>
-        <netty.transport.native.epoll.version>4.2.12.Final</netty.transport.native.epoll.version>
+        <netty.codec.http.version>4.2.13.Final</netty.codec.http.version>
+        <netty.codec.http2.version>4.2.13.Final</netty.codec.http2.version>
+        <netty.transport.native.epoll.version>4.2.13.Final</netty.transport.native.epoll.version>
         <json.version>20251224</json.version>
         <guava.version>33.5.0-jre</guava.version>
         <httpclient.version>4.5.14</httpclient.version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -62,8 +62,8 @@
     <owasp-dependency-check-plugin.version>12.2.1</owasp-dependency-check-plugin.version>
     <auth0-spring-security-api.version>1.4.1</auth0-spring-security-api.version>
     <io-projectreactor-netty.version>1.0.8</io-projectreactor-netty.version>
-    <netty.codec.http.version>4.2.12.Final</netty.codec.http.version>
-    <netty.codec.http2.version>4.2.12.Final</netty.codec.http2.version>
+    <netty.codec.http.version>4.2.13.Final</netty.codec.http.version>
+    <netty.codec.http2.version>4.2.13.Final</netty.codec.http2.version>
     <netty.transport.native.epoll.version>4.2.9.Final</netty.transport.native.epoll.version>
     <log4j-version>2.25.4</log4j-version>
     <logback.version>1.5.32</logback.version>


### PR DESCRIPTION
#### 📲 What

Bumps Netty to 4.2.13.Final to mitigate CVE-2026-42577.

#### 🤔 Why

As part of our responsibilities under ISO27001, we are required to manage and mitigate risks associated with software vulnerabilities. By enforcing a secure version of Ensono Stacks, we reduce the risk of known vulnerabilities being exploited in our development environment. This proactive approach to dependency management demonstrates our commitment to maintaining the confidentiality, integrity, and availability of our information assets, as required by ISO27001 controls on software development and vulnerability management.

#### 🛠 How

Updated both `pom.xml` to upgrade.

#### 👀 Evidence

CI

#### 🕵️ How to test

CI

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [X] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [X] Passing any exploratory testing?
- [X] Rebased/merged with latest changes from development and re-tested?
- [X] Meeting the Coding Standards?
