### PR TITLE
fix: CVE-2026-41305

### DIFF
--- a/build/azDevOps/azure/coverage/package-lock.json
+++ b/build/azDevOps/azure/coverage/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "coverage",
       "license": "Apache-2.0",
       "devDependencies": {
         "gulp": "^5.0.1",
@@ -2686,9 +2687,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {
@@ -2704,6 +2705,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
@@ -3627,15 +3629,19 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/build/azDevOps/azure/coverage/package.json
+++ b/build/azDevOps/azure/coverage/package.json
@@ -5,7 +5,8 @@
   "overrides": {
     "inline-source": "8.0.3",
     "picomatch": "2.3.2",
-    "svgo": "3.3.3"
+    "svgo": "3.3.3",
+    "postcss": "8.5.10"
   },
   "devDependencies": {
     "gulp": "^5.0.1",


### PR DESCRIPTION
#### 📲 What

Fixes CVE-2026-41305

#### 🤔 Why

As part of our responsibilities under ISO27001, we are required to manage and mitigate risks associated with software vulnerabilities. By enforcing a secure version of Ensono Stacks, we reduce the risk of known vulnerabilities being exploited in our development environment. This proactive approach to dependency management demonstrates our commitment to maintaining the confidentiality, integrity, and availability of our information assets, as required by ISO27001 controls on software development and vulnerability management.

#### 🛠 How

Override dep.

#### 👀 Evidence

```
 $ npm ls postcss
coverage@ /home/rslater/source/stacks-java-cqrs-events/build/azDevOps/azure/coverage
├─┬ gulp-postcss@10.0.0
│ ├─┬ postcss-load-config@5.1.0
│ │ └── postcss@8.5.10 deduped
│ └── postcss@8.5.10 overridden
└─┬ postcss-image-inliner@7.0.1
  └── postcss@8.5.10 deduped

 $ npm audit
found 0 vulnerabilities
```

#### 🕵️ How to test

CI

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [X] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [X] Passing any exploratory testing?
- [X] Rebased/merged with latest changes from development and re-tested?
- [X] Meeting the Coding Standards?
